### PR TITLE
Rework the CKAN Explorer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,21 @@
+.navbar-inner {
+  background-color: #ffffff;
+  background-image: none;
+}
+
+li .js-add-resource {
+  padding-right: 75px;
+}
+
+li .btn {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
 html, body {
   background-color: #7285AC;
 }
+
 body {
   padding-top: 40px;
   font-family: 'PT Sans', Helvetica, Arial, sans-serif;
@@ -14,7 +29,7 @@ body {
 
 .content {
   background-color: #fff;
-  padding: 20px;
+  padding: 60px 20px 20px 20px;
   margin: 0 -20px;
   -webkit-box-shadow: 0 1px 2px rgba(0,0,0,.15);
      -moz-box-shadow: 0 1px 2px rgba(0,0,0,.15);
@@ -52,7 +67,7 @@ footer {
   *******************************************************************/
 
 .recline-query-editor .text-query input {
-  width: 400px;
+  width: 300px;
 }
 
 .recline-query-editor button {
@@ -76,18 +91,26 @@ footer {
   list-style-type: none;
 }
 
+.data-search input, br {
+  display: none;
+}
+
 .data-search .resource-list li {
   border-left: solid #eee 3px;
   padding-left: 5px;
   margin-bottom: 2px;
   background-color: #eee;
   text-decoration: line-through;
+  font-size: 13px;
 }
 
 .data-search .resource-list li.active {
   border-left: solid orange 3px;
   background-color: #eee;
   text-decoration: none;
+  padding-top: 3px;
+  padding-bottom: 10px;
+  padding-right: 3px;
 }
 
 /********************************************************************

--- a/index.html
+++ b/index.html
@@ -30,17 +30,16 @@
   <div class="navbar-inner">
     <div class="container">
       <a class="brand" href="#">CKAN Data Explorer</a>
-        <ul class="nav">
-          <li class="divider-vertical"></li>
-        </ul>
-        <ul class="nav pull-right">
-          <li>
-            <a class="nav-logo pull-left" href="http://okfnlabs.org/" title="An Open Knowledge Foundation Project">
-              <img src="http://assets.okfn.org/p/labs/img/logo-s.png" alt="Open Knowledge Foundation logo" style="height: 30px" />
-            </a>
-          </li>
-        </ul>
-      </div>
+      <ul class="nav">
+        <li class="divider-vertical"></li>
+      </ul>
+      <ul class="nav pull-right">
+        <li>
+          <a class="nav-logo pull-left" href="http://okfnlabs.org/" title="An Open Knowledge Foundation Project">
+            <img src="http://assets.okfn.org/p/labs/img/logo-s.png" alt="Open Knowledge Foundation logo" style="height: 30px" />
+          </a>
+        </li>
+      </ul>
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -28,63 +28,64 @@
 <body>
 <div class="navbar navbar-fixed-top">
   <div class="navbar-inner">
-<div class="container">
-  <a class="brand" href="#">CKAN Data Explorer</a>
-    <ul class="nav">
-      <li class="divider-vertical"></li>
-    </ul>
-      <ul class="nav pull-right">
-        <li>
-          <a class="nav-logo pull-left" href="http://okfnlabs.org/" title="An Open Knowledge Foundation Project">
-            <img src="http://assets.okfn.org/p/labs/img/logo-s.png" alt="Open Knowledge Foundation logo" style="height: 30px" />
-          </a>
-        </li>
-      </ul>
+    <div class="container">
+      <a class="brand" href="#">CKAN Data Explorer</a>
+        <ul class="nav">
+          <li class="divider-vertical"></li>
+        </ul>
+        <ul class="nav pull-right">
+          <li>
+            <a class="nav-logo pull-left" href="http://okfnlabs.org/" title="An Open Knowledge Foundation Project">
+              <img src="http://assets.okfn.org/p/labs/img/logo-s.png" alt="Open Knowledge Foundation logo" style="height: 30px" />
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 
 <div class="container">
-<div class="content">
-  <div class="view home">
-    <div class="row">
-      <div class="span9">
-        <div class="intro-div">
-          <h1>
-            Welcome
-            <br />
-            <small>
-              This application let's you explore, analyze and visualize data stored in a CKAN DataStore.
-            </small>
-          </h1>
-          <h3>Get Started</h3>
-          <p>Search for data to add in the sidebar. This will display datases
-          along with their data resources. If the data resource has data stored
-          in the DataStore you'll then be able to view it by clicking on
-          it.</p>
+  <div class="content">
+    <div class="view home">
+      <div class="row">
+        <div class="span9">
+          <div class="intro-div">
+            <h1>
+              Welcome
+              <br />
+              <small>
+                This application let's you explore, analyze and visualize data stored in a CKAN DataStore.
+              </small>
+            </h1>
+            <h3>Get Started</h3>
+            <p>Search for data to add in the sidebar. This will display datases
+            along with their data resources. If the data resource has data stored
+            in the DataStore you'll then be able to view it by clicking on
+            it.</p>
+          </div>
+          <div class="data-views-container"></div>
         </div>
-        <div class="data-views-container"></div>
-      </div>
-      <div class="span3">
-        <div class="dataset-search-here"></div>
-        <!--img src="http://assets.okfn.org/images/icons/ajaxload-circle.gif" class="loading" /-->
-        <div class="placeholder-search"></div>
+        <div class="span3">
+          <div class="dataset-search-here"></div>
+          <!--img src="http://assets.okfn.org/images/icons/ajaxload-circle.gif" class="loading" /-->
+          <div class="placeholder-search"></div>
+        </div>
       </div>
     </div>
-  </div>
 
-  <footer>
-    <p>
-      <a href="http://github.com/rgrp/ckan-explorer">Source Code</a> 
-    </p>
-    <p>
-      <a href="http://opendefinition.org/okd/" title="Open Data">
-        <img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="" border="" /></a>
-      <a href="http://opendefinition.org/ossd/" title="Open Online Software Service">
-        <img src="http://assets.okfn.org/images/ok_buttons/os_80x15_orange_grey.png" alt="" border="" />
-      </a>
-    </p>
-  </footer>
+    <footer>
+      <p>
+        <a href="http://github.com/rgrp/ckan-explorer">Source Code</a> 
+      </p>
+      <p>
+        <a href="http://opendefinition.org/okd/" title="Open Data">
+          <img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png" alt="" border="" /></a>
+        <a href="http://opendefinition.org/ossd/" title="Open Online Software Service">
+          <img src="http://assets.okfn.org/images/ok_buttons/os_80x15_orange_grey.png" alt="" border="" />
+        </a>
+      </p>
+    </footer>
   </div><!-- /content -->
 </div><!-- /container -->
 

--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
 
   <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
   <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <link rel="stylesheet" href="vendor/recline/vendor/leaflet/0.4.4/leaflet.ie.css">
     <link rel="stylesheet" href="vendor/recline/vendor/leaflet.markercluster/MarkerCluster.Default.ie.css">
   <![endif]-->
 
-  <link href="http://fonts.googleapis.com/css?family=PT+Sans" rel="stylesheet" type="text/css">
-  <link href="http://netdna.bootstrapcdn.com/bootstrap/2.3.2/css/bootstrap.min.css" rel="stylesheet" />
-  <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.0/css/font-awesome.css" rel="stylesheet">
+  <link href="//fonts.googleapis.com/css?family=PT+Sans" rel="stylesheet" type="text/css">
+  <link href="//netdna.bootstrapcdn.com/bootstrap/2.3.2/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.0/css/font-awesome.css" rel="stylesheet">
 
   <link rel="stylesheet" href="vendor/recline/vendor/slickgrid/2.0.1/slick.grid.css">
   <link rel="stylesheet" href="vendor/recline/vendor/leaflet/0.4.4/leaflet.css">
@@ -28,11 +28,11 @@
 <body>
 <div class="navbar navbar-fixed-top">
   <div class="navbar-inner">
-    <div class="container">
-      <a class="brand" href="#">CKAN Data Explorer</a>
-      <ul class="nav">
-        <li class="divider-vertical"></li>
-      </ul>
+<div class="container">
+  <a class="brand" href="#">CKAN Data Explorer</a>
+    <ul class="nav">
+      <li class="divider-vertical"></li>
+    </ul>
       <ul class="nav pull-right">
         <li>
           <a class="nav-logo pull-left" href="http://okfnlabs.org/" title="An Open Knowledge Foundation Project">
@@ -75,10 +75,7 @@
 
   <footer>
     <p>
-      This service is run by the <a href="http://okfn.org">Open
-        Knowledge Foundation</a>
-      &ndash;
-      <a href="http://github.com/rgrp/ckan-explorer">Source Code</a>
+      <a href="http://github.com/rgrp/ckan-explorer">Source Code</a> 
     </p>
     <p>
       <a href="http://opendefinition.org/okd/" title="Open Data">

--- a/js/app.js
+++ b/js/app.js
@@ -1,163 +1,156 @@
+
 // will be setup in document ready below as we need to parse query string
 var ckan = null;
 var startDataset = null;
-
 var DataView = Backbone.View.extend({
-class: 'data-view',
-initialize: function(options) {
-var self = this;
-// var resource = new Backbone.Model
-this.dataset = new recline.Model.Dataset({
-endpoint: options.endpoint,
-id: options.resourceId,
-backend: 'ckan'
-});
-this.dataset.fetch()
-.done(function() {
-self.render();
-});
-//    client.action('datastore_search', {resource_id: options.resourceId}, function(err, out) {
-//      if (err) {
-//        console.error(err)
-//        console.log(JSON.parse(err.message));
-//        return;
-//      };
-//    });
-},
-
-render: function() {
-var html = Mustache.render(this.template, {resource: this.dataset.toJSON()});
-this.$el.html(html);
-
-this.view = this._makeMultiView(this.dataset, this.$el.find('.multiview'));
-this.dataset.query({size: this.dataset.recordCount});
-},
-
-_makeMultiView: function(dataset, $el) {
-var gridView = {
-id: 'grid',
-label: 'Grid',
-view: new recline.View.SlickGrid({
-  model: dataset,
-  state: {
-    fitColumns: true
+  class: 'data-view',
+  initialize: function(options) {
+    var self = this;
+    // var resource = new Backbone.Model
+    this.dataset = new recline.Model.Dataset({
+      endpoint: options.endpoint,
+      id: options.resourceId,
+      backend: 'ckan'
+    });
+    this.dataset.fetch()
+      .done(function() {
+        self.render();
+      });
+    //    client.action('datastore_search', {resource_id: options.resourceId}, function(err, out) {
+    //      if (err) {
+    //        console.error(err)
+    //        console.log(JSON.parse(err.message));
+    //        return;
+    //      };
+    //    });
+  },
+  render: function() {
+    var html = Mustache.render(this.template, {
+      resource: this.dataset.toJSON()
+    });
+    this.$el.html(html);
+    this.view = this._makeMultiView(this.dataset, this.$el.find('.multiview'));
+    this.dataset.query({
+      size: this.dataset.recordCount
+    });
+  },
+  _makeMultiView: function(dataset, $el) {
+    var gridView = {
+      id: 'grid',
+      label: 'Grid',
+      view: new recline.View.SlickGrid({
+        model: dataset,
+        state: {
+          fitColumns: true
+        }
+      })
+    };
+    var graphView = {
+      id: 'graph',
+      label: 'Graph',
+      view: new recline.View.Flot({
+        model: dataset
+      })
+    };
+    var mapView = {
+      id: 'map',
+      label: 'Map',
+      view: new recline.View.Map({
+        model: dataset
+      })
+    };
+    view = new recline.View.MultiView({
+      model: dataset,
+      views: [gridView, graphView, mapView],
+      sidebarViews: [],
+      el: $el
+    });
+    return view;
+  },
+  events: {
+    'submit .query-sql': 'sqlQuery',
+    'click #save': 'saveResource'
+  },
+  template: ' \
+    <form class="form query-sql"> \
+      <h3>SQL Query</h3> \
+      <p class="help-block">Query this table using SQL via the <a href="http://docs.ckan.org/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search_sql">DataStore SQL API</a></p> \
+      <textarea style="width: 95%;">SELECT * FROM "{{resource.id}}"</textarea><br> \
+      <div class="sql-error alert alert-error" style="display: none;"></div> \
+      <button type="submit" class="btn btn-primary">Query</button> \
+      <button type="submit" id="save" title="Future work!" class="disabled btn btn-primary">Save <em>current</em> results as new resource</button> \
+    </form> \
+    <div class="sql-results"></div> \
+    <div class="multiview"></div> \
+  ',
+  saveResource: function(e) {
+    var self = this;
+    e.preventDefault();
+    alert('Not done yet!');
+  },
+  sqlQuery: function(e) {
+    var self = this;
+    e.preventDefault();
+    var $error = this.$el.find('.sql-error');
+    $error.hide();
+    var sql = this.$el.find('.query-sql textarea').val();
+    // replace ';' on end of sql as seems to trigger a json error
+    sql = sql.replace(/;$/, '');
+    ckan.datastoreSqlQuery(sql, function(err, data) {
+      if (err) {
+        var msg = '<p>Error: ' + err.message + '</p>';
+        $error.html(msg);
+        $error.show('slow');
+        return;
+      }
+      // now handle good case ...
+      var dataset = new recline.Model.Dataset({
+        records: data.hits,
+        fields: data.fields
+      });
+      dataset.fetch();
+      // remove existing stuff
+      $('.multiview').remove();
+      // destroy existing view ...
+      var $el = $('<div />');
+      $('.sql-results').append($el);
+      if (self.sqlResultsView) {
+        self.sqlResultsView.remove();
+      }
+      self.sqlResultsView = self._makeMultiView(dataset, $el);
+      dataset.query({
+        size: dataset.recordCount
+      });
+    });
   }
-})
-};
-var graphView = {
-id: 'graph',
-label: 'Graph',
-view: new recline.View.Flot({
-model: dataset
-})
-};
-var mapView = {
-id: 'map',
-label: 'Map',
-view: new recline.View.Map({
-model: dataset
-})
-};
-view = new recline.View.MultiView({
-model: dataset,
-views: [gridView, graphView, mapView],
-sidebarViews: [],
-el: $el
 });
-return view;
-},
-
-
-events: {
-'submit .query-sql': 'sqlQuery',
-'click #save': 'saveResource'
-},
-
-template: ' \
-<form class="form query-sql"> \
-<h3>SQL Query</h3> \
-<p class="help-block">Query this table using SQL via the <a href="http://docs.ckan.org/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search_sql">DataStore SQL API</a></p> \
-<textarea style="width: 95%;">SELECT * FROM "{{resource.id}}"</textarea><br> \
-<div class="sql-error alert alert-error" style="display: none;"></div> \
-<button type="submit" class="btn btn-primary">Query</button> \
-<button type="submit" id="save" class="btn btn-primary">Save <em>current</em> results as new resource</button> \
-</form> \
-<div class="sql-results"></div> \
-<div class="multiview"></div> \
-',
-
-saveResource: function(e) {
-var self = this;
-e.preventDefault();
-alert('Not done yet!');
-},
-
-sqlQuery: function(e) {
-var self = this;
-e.preventDefault();
-
-var $error = this.$el.find('.sql-error');
-$error.hide();
-var sql = this.$el.find('.query-sql textarea').val();
-// replace ';' on end of sql as seems to trigger a json error
-sql = sql.replace(/;$/, '');
-ckan.datastoreSqlQuery(sql, function(err, data) {
-if (err) {
-var msg = '<p>Error: ' + err.message + '</p>';
-$error.html(msg);
-$error.show('slow');
-return;
-}
-
-// now handle good case ...
-var dataset = new recline.Model.Dataset({
-records: data.hits,
-fields: data.fields
-});
-dataset.fetch();
-// remove existing stuff
-$('.multiview').remove();
-// destroy existing view ...
-var $el = $('<div />');
-$('.sql-results').append($el);
-if (self.sqlResultsView) {
-self.sqlResultsView.remove();
-}
-
-self.sqlResultsView = self._makeMultiView(dataset, $el);
-dataset.query({size: dataset.recordCount});
-});
-}
-});
-
-
 var CKANSearchWidget = Backbone.View.extend({
-template: '\
-<div class="data-search"> \
-<h3>Available tables</h3> \
-<form class="form">\
-<input type="search" value="{{q}}" placeholder="Search for data" />\
-<br />\
-<p class="help-block">We\'ll only show datasets where data is in the DataStore</p> \
-</form>\
-<ul class="dataset-list"></ul>\
-</div> \
-',
-templateDataset: ' \
-<div class="dataset summary"> \
-<h4>{{title}}</h4> \
-{{# resources }}\
-<ul class="resource-list">\
-{{# datastore_active}} \
-        <li class="active"> \
-          <a href="#" class="js-add-resource" data-id="{{id}}">{{ name }}</a><br>&nbsp;<a class="btn btn-primary btn-mini pull-right" href="?endpoint={{endpoint}}&apikey={{apikey}}&dataset={{id}}" target="_blank">New Tab</a> \
-        {{/ datastore_active}} \
-        {{^ datastore_active }} \
-        <li> \
-           <!-- <span title="not in DataStore">{{ name }}</span> --> \
-        {{/ datastore_active }} \
-        </li> \
-      </ul> \
+  template: '\
+    <div class="data-search"> \
+      <h3>Available tables</h3> \
+        <form class="form">\
+          <input type="search" value="{{q}}" placeholder="Search for data" />\
+          <br />\
+          <p class="help-block">We\'ll only show datasets where data is in the DataStore</p> \
+        </form>\
+        <ul class="dataset-list"></ul>\
+    </div> \
+  ',
+  templateDataset: ' \
+    <div class="dataset summary"> \
+      <h4>{{title}}</h4> \
+      {{# resources }}\
+        <ul class="resource-list">\
+          {{# datastore_active}} \
+            <li class="active"> \
+              <a href="#" class="js-add-resource" data-id="{{id}}">{{ name }}</a><br>&nbsp;<a class="btn btn-primary btn-mini pull-right" href="?endpoint={{endpoint}}&apikey={{apikey}}&dataset={{id}}" target="_blank">New Tab</a> \
+          {{/ datastore_active}} \
+          {{^ datastore_active }} \
+            <li> \
+              <!-- <span title="not in DataStore">{{ name }}</span> --> \
+          {{/ datastore_active }} \
+          </li> \
+        </ul> \
       {{/resources }}\
     <div> \
   ',
@@ -171,7 +164,10 @@ templateDataset: ' \
     _.bindAll(this, 'render');
     this.collection.bind('reset', this.render);
     // first get list of all resources in the datastore
-    ckan.action('datastore_search', {resource_id: '_table_metadata', limit: 100000}, function(err, out) 
+    ckan.action('datastore_search', {
+      resource_id: '_table_metadata',
+      limit: 100000
+    }, function(err, out)
     {
       self.resourcesInDatastore = _.pluck(out.result.records, 'name');
       self.query();
@@ -179,7 +175,9 @@ templateDataset: ' \
   },
   render: function() {
     var self = this;
-    var html = Mustache.render(this.template, {q: this.currentQuery});
+    var html = Mustache.render(this.template, {
+      q: this.currentQuery
+    });
     this.$el.html(html);
     this.collection.each(function(dataset) {
       var stuff = dataset.toJSON();
@@ -196,9 +194,12 @@ templateDataset: ' \
       e.preventDefault();
     }
     this.currentQuery = $('form input[type="search"]').val();
-    ckan.action('package_search', {include_private: true, q: this.currentQuery}, function(err, out) {
-     var subkey = "results"; 
-     _.each(out.result[subkey], function(dataset) {
+    ckan.action('package_search', {
+      include_private: true,
+      q: this.currentQuery
+    }, function(err, out) {
+      var subkey = "results";
+      _.each(out.result[subkey], function(dataset) {
         // should have datastore_active set but unfortunately not ...
         // see https://raw.github.com/datasets/gold-prices/master/data/data.csv
         _.each(dataset.resources, function(res) {
@@ -214,7 +215,7 @@ templateDataset: ' \
       if (startDataset) {
         self.trigger('resource:select', startDataset);
       }
-     });
+    });
   },
   _selectResource: function(e) {
     e.preventDefault();
@@ -222,7 +223,6 @@ templateDataset: ' \
     this.trigger('resource:select', id);
   }
 });
-
 jQuery(document).ready(function($) {
   var $el = $('.dataset-search-here');
   // support for using query string state
@@ -238,9 +238,8 @@ jQuery(document).ready(function($) {
     startDataset = qs.dataset;
   }
   var search = new CKANSearchWidget({
-      el: $el
+    el: $el
   });
-
   var $container = $('.data-views-container');
   search.on('resource:select', function(id) {
     $('.intro-div').hide('slow');
@@ -253,22 +252,19 @@ jQuery(document).ready(function($) {
       el: $el
     });
   });
-
   if (qs.resource) {
     search.trigger('resource:select', qs.resource);
   }
 });
-
 parseQueryString = function(q) {
   if (!q) {
     return {};
   }
   var urlParams = {},
-    e, d = function (s) {
+    e, d = function(s) {
       return decodeURIComponent(s.replace(/\+/g, " "));
     },
     r = /([^&=]+)=?([^&]*)/g;
-
   if (q && q.length && q[0] === '?') q = q.slice(1);
   while (e = r.exec(q)) {
     // TODO: have values be array as query string allow repetition of keys

--- a/js/app.js
+++ b/js/app.js
@@ -1,20 +1,21 @@
 // will be setup in document ready below as we need to parse query string
 var ckan = null;
+var startDataset = null;
 
 var DataView = Backbone.View.extend({
-  class: 'data-view',
-  initialize: function(options) {
-    var self = this;
-    // var resource = new Backbone.Model
-    this.dataset = new recline.Model.Dataset({
-      endpoint: options.endpoint,
-      id: options.resourceId,
-      backend: 'ckan'
-    });
-    this.dataset.fetch()
-      .done(function() {
-        self.render();
-      });
+class: 'data-view',
+initialize: function(options) {
+var self = this;
+// var resource = new Backbone.Model
+this.dataset = new recline.Model.Dataset({
+endpoint: options.endpoint,
+id: options.resourceId,
+backend: 'ckan'
+});
+this.dataset.fetch()
+.done(function() {
+self.render();
+});
 //    client.action('datastore_search', {resource_id: options.resourceId}, function(err, out) {
 //      if (err) {
 //        console.error(err)
@@ -22,127 +23,138 @@ var DataView = Backbone.View.extend({
 //        return;
 //      };
 //    });
-  },
+},
 
-  render: function() {
-    var html = Mustache.render(this.template, {resource: this.dataset.toJSON()});
-    this.$el.html(html);
+render: function() {
+var html = Mustache.render(this.template, {resource: this.dataset.toJSON()});
+this.$el.html(html);
 
-    this.view = this._makeMultiView(this.dataset, this.$el.find('.multiview'));
-    this.dataset.query({size: this.dataset.recordCount});
-  },
+this.view = this._makeMultiView(this.dataset, this.$el.find('.multiview'));
+this.dataset.query({size: this.dataset.recordCount});
+},
 
-  _makeMultiView: function(dataset, $el) {
-    var gridView = {
-        id: 'grid',
-        label: 'Grid',
-        view: new recline.View.SlickGrid({
-          model: dataset,
-          state: {
-            fitColumns: true
-          }
-        })
-      };
-    var graphView = {
-      id: 'graph',
-      label: 'Graph',
-      view: new recline.View.Flot({
-        model: dataset
-      })
-    };
-    var mapView = {
-      id: 'map',
-      label: 'Map',
-      view: new recline.View.Map({
-        model: dataset
-      })
-    };
-    view = new recline.View.MultiView({
-      model: dataset,
-      views: [gridView, graphView, mapView],
-      sidebarViews: [],
-      el: $el
-    });
-    return view;
-  },
-
-
-  events: {
-    'submit .query-sql': 'sqlQuery'
-  },
-
-  template: ' \
-    <form class="form query-sql"> \
-      <h3>SQL Query</h3> \
-      <p class="help-block">Query this table using SQL via the <a href="http://docs.ckan.org/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search_sql">DataStore SQL API</a></p> \
-      <textarea style="width: 100%;">SELECT * FROM "{{resource.id}}"</textarea> \
-      <div class="sql-error alert alert-error" style="display: none;"></div> \
-      <button type="submit" class="btn btn-primary">Query</button> \
-    </form> \
-    <div class="sql-results"></div> \
-    <div class="multiview"></div> \
-    ',
-
-  sqlQuery: function(e) {
-    var self = this;
-    e.preventDefault();
-
-    var $error = this.$el.find('.sql-error');
-    $error.hide();
-    var sql = this.$el.find('.query-sql textarea').val();
-    // replace ';' on end of sql as seems to trigger a json error
-    sql = sql.replace(/;$/, '');
-    ckan.datastoreSqlQuery(sql, function(err, data) {
-      if (err) {
-        var msg = '<p>Error: ' + err.message + '</p>';
-        $error.html(msg);
-        $error.show('slow');
-        return;
-      }
-
-      // now handle good case ...
-      var dataset = new recline.Model.Dataset({
-        records: data.hits,
-        fields: data.fields
-      });
-      dataset.fetch();
-      // destroy existing view ...
-      var $el = $('<div />');
-      $('.sql-results').append($el);
-      if (self.sqlResultsView) {
-        self.sqlResultsView.remove();
-      }
-
-      self.sqlResultsView = self._makeMultiView(dataset, $el);
-      dataset.query({size: dataset.recordCount});
-    });
+_makeMultiView: function(dataset, $el) {
+var gridView = {
+id: 'grid',
+label: 'Grid',
+view: new recline.View.SlickGrid({
+  model: dataset,
+  state: {
+    fitColumns: true
   }
+})
+};
+var graphView = {
+id: 'graph',
+label: 'Graph',
+view: new recline.View.Flot({
+model: dataset
+})
+};
+var mapView = {
+id: 'map',
+label: 'Map',
+view: new recline.View.Map({
+model: dataset
+})
+};
+view = new recline.View.MultiView({
+model: dataset,
+views: [gridView, graphView, mapView],
+sidebarViews: [],
+el: $el
+});
+return view;
+},
+
+
+events: {
+'submit .query-sql': 'sqlQuery',
+'click #save': 'saveResource'
+},
+
+template: ' \
+<form class="form query-sql"> \
+<h3>SQL Query</h3> \
+<p class="help-block">Query this table using SQL via the <a href="http://docs.ckan.org/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search_sql">DataStore SQL API</a></p> \
+<textarea style="width: 95%;">SELECT * FROM "{{resource.id}}"</textarea><br> \
+<div class="sql-error alert alert-error" style="display: none;"></div> \
+<button type="submit" class="btn btn-primary">Query</button> \
+<button type="submit" id="save" class="btn btn-primary">Save <em>current</em> results as new resource</button> \
+</form> \
+<div class="sql-results"></div> \
+<div class="multiview"></div> \
+',
+
+saveResource: function(e) {
+var self = this;
+e.preventDefault();
+alert('Not done yet!');
+},
+
+sqlQuery: function(e) {
+var self = this;
+e.preventDefault();
+
+var $error = this.$el.find('.sql-error');
+$error.hide();
+var sql = this.$el.find('.query-sql textarea').val();
+// replace ';' on end of sql as seems to trigger a json error
+sql = sql.replace(/;$/, '');
+ckan.datastoreSqlQuery(sql, function(err, data) {
+if (err) {
+var msg = '<p>Error: ' + err.message + '</p>';
+$error.html(msg);
+$error.show('slow');
+return;
+}
+
+// now handle good case ...
+var dataset = new recline.Model.Dataset({
+records: data.hits,
+fields: data.fields
+});
+dataset.fetch();
+// remove existing stuff
+$('.multiview').remove();
+// destroy existing view ...
+var $el = $('<div />');
+$('.sql-results').append($el);
+if (self.sqlResultsView) {
+self.sqlResultsView.remove();
+}
+
+self.sqlResultsView = self._makeMultiView(dataset, $el);
+dataset.query({size: dataset.recordCount});
+});
+}
 });
 
 
 var CKANSearchWidget = Backbone.View.extend({
-  template: '\
-    <div class="data-search"> \
-      <form class="form">\
-        <input type="search" value="{{q}}" placeholder="Search for data" />\
-        <br />\
-        <p class="help-block">We\'ll only show datasets where data is in the DataStore</p> \
-      </form>\
-      <ul class="dataset-list"></ul>\
-    </div> \
-  ',
-  templateDataset: ' \
-    <div class="dataset summary"> \
-      <h4>{{title}}</h4> \
-      {{# resources }}\
-      <ul class="resource-list">\
-        {{# datastore_active}} \
+template: '\
+<div class="data-search"> \
+<h3>Available tables</h3> \
+<form class="form">\
+<input type="search" value="{{q}}" placeholder="Search for data" />\
+<br />\
+<p class="help-block">We\'ll only show datasets where data is in the DataStore</p> \
+</form>\
+<ul class="dataset-list"></ul>\
+</div> \
+',
+templateDataset: ' \
+<div class="dataset summary"> \
+<h4>{{title}}</h4> \
+{{# resources }}\
+<ul class="resource-list">\
+{{# datastore_active}} \
         <li class="active"> \
-          <a href="#" class="js-add-resource" data-id="{{id}}">{{ name }}</a> \
+          <a href="#" class="js-add-resource" data-id="{{id}}">{{ name }}</a><br>&nbsp;<a class="btn btn-primary btn-mini pull-right" href="?endpoint={{endpoint}}&apikey={{apikey}}&dataset={{id}}" target="_blank">New Tab</a> \
         {{/ datastore_active}} \
         {{^ datastore_active }} \
         <li> \
-            <span title="not in DataStore">{{ name }}</span> \
+           <!-- <span title="not in DataStore">{{ name }}</span> --> \
         {{/ datastore_active }} \
         </li> \
       </ul> \
@@ -159,7 +171,8 @@ var CKANSearchWidget = Backbone.View.extend({
     _.bindAll(this, 'render');
     this.collection.bind('reset', this.render);
     // first get list of all resources in the datastore
-    ckan.action('datastore_search', {resource_id: '_table_metadata', limit: 100000}, function(err, out) {
+    ckan.action('datastore_search', {resource_id: '_table_metadata', limit: 100000}, function(err, out) 
+    {
       self.resourcesInDatastore = _.pluck(out.result.records, 'name');
       self.query();
     });
@@ -169,7 +182,10 @@ var CKANSearchWidget = Backbone.View.extend({
     var html = Mustache.render(this.template, {q: this.currentQuery});
     this.$el.html(html);
     this.collection.each(function(dataset) {
-      var html = Mustache.render(self.templateDataset, dataset.toJSON());
+      var stuff = dataset.toJSON();
+      stuff.apikey = ckan.apiKey;
+      stuff.endpoint = ckan.endpoint;
+      var html = Mustache.render(self.templateDataset, stuff);
       self.$el.find('.dataset-list').append(html);
     });
     return this;
@@ -179,23 +195,26 @@ var CKANSearchWidget = Backbone.View.extend({
     if (e) {
       e.preventDefault();
     }
-    this.currentQuery = this.$('form input[type="search"]').val();
-    ckan.action('current_package_list_with_resources', {q: this.currentQuery}, function(err, out) {
-      _.each(out.result, function(dataset) {
+    this.currentQuery = $('form input[type="search"]').val();
+    ckan.action('package_search', {include_private: true, q: this.currentQuery}, function(err, out) {
+     var subkey = "results"; 
+     _.each(out.result[subkey], function(dataset) {
         // should have datastore_active set but unfortunately not ...
         // see https://raw.github.com/datasets/gold-prices/master/data/data.csv
         _.each(dataset.resources, function(res) {
           // make sure it has a name because we use it in the templating ...
           res.name = res.name || res.description.slice(0, 30) || 'No name';
-          console.log(res.id);
           // console.log(self.resourcesInDatastore);
           if (self.resourcesInDatastore.indexOf(res.id) != -1) {
             res.datastore_active = true;
           }
         });
       });
-      self.collection.reset(out.result);
-    });
+      self.collection.reset(out.result[subkey]);
+      if (startDataset) {
+        self.trigger('resource:select', startDataset);
+      }
+     });
   },
   _selectResource: function(e) {
     e.preventDefault();
@@ -208,22 +227,25 @@ jQuery(document).ready(function($) {
   var $el = $('.dataset-search-here');
   // support for using query string state
   var qs = parseQueryString(location.search);
-  var endpoint = qs.endpoint || 'http://demo.ckan.org';
+  var endpoint = qs.endpoint || '//demo.ckan.org';
   var apikey = qs.apikey || '';
   if (!endpoint.match(/api$/)) {
     endpoint += '/api'
   }
   // defined in global namespace above but set to null
   ckan = new CKAN.Client(endpoint, apikey)
-
+  if (qs.dataset) {
+    startDataset = qs.dataset;
+  }
   var search = new CKANSearchWidget({
-    el: $el
+      el: $el
   });
 
   var $container = $('.data-views-container');
   search.on('resource:select', function(id) {
     $('.intro-div').hide('slow');
     var $el = $('<div class="data-view"></div>');
+    $('.data-view').remove();
     $container.append($el);
     var view = new DataView({
       resourceId: id,

--- a/js/app.js
+++ b/js/app.js
@@ -180,21 +180,21 @@ var CKANSearchWidget = Backbone.View.extend({
       e.preventDefault();
     }
     this.currentQuery = this.$('form input[type="search"]').val();
-    ckan.action('dataset_search', {q: this.currentQuery}, function(err, out) {
-      _.each(out.result.results, function(dataset) {
+    ckan.action('current_package_list_with_resources', {q: this.currentQuery}, function(err, out) {
+      _.each(out.result, function(dataset) {
         // should have datastore_active set but unfortunately not ...
         // see https://raw.github.com/datasets/gold-prices/master/data/data.csv
         _.each(dataset.resources, function(res) {
           // make sure it has a name because we use it in the templating ...
           res.name = res.name || res.description.slice(0, 30) || 'No name';
-          // console.log(res.id);
+          console.log(res.id);
           // console.log(self.resourcesInDatastore);
           if (self.resourcesInDatastore.indexOf(res.id) != -1) {
             res.datastore_active = true;
           }
         });
       });
-      self.collection.reset(out.result.results);
+      self.collection.reset(out.result);
     });
   },
   _selectResource: function(e) {
@@ -209,11 +209,12 @@ jQuery(document).ready(function($) {
   // support for using query string state
   var qs = parseQueryString(location.search);
   var endpoint = qs.endpoint || 'http://demo.ckan.org';
+  var apikey = qs.apikey || '';
   if (!endpoint.match(/api$/)) {
     endpoint += '/api'
   }
   // defined in global namespace above but set to null
-  ckan = new CKAN.Client(endpoint)
+  ckan = new CKAN.Client(endpoint, apikey)
 
   var search = new CKANSearchWidget({
     el: $el


### PR DESCRIPTION
- Single dataset operation: supply dataset in the URL and we go directly to that resource
- Support grabbing data from CKAN user's private datasets (requires a very recent version of CKAN)
- Don't append resource views but rather replace them so that ckan explorer becomes more of a single-page SQL tool; for opening multiple resources there are buttons to open them in new tabs
- Minor formatting changes (code and appearance)

See also:
https://github.com/ckan/ckan/pull/3191
https://github.com/okfn/ckan.js/pull/25