### PR TITLE
Send the apiKey into recline as part of the dataset/backend options

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,7 @@ var DataView = Backbone.View.extend({
     this.dataset = new recline.Model.Dataset({
       endpoint: options.endpoint,
       id: options.resourceId,
+      apiKey: options.apiKey,
       backend: 'ckan'
     });
     this.dataset.fetch()
@@ -249,6 +250,7 @@ jQuery(document).ready(function($) {
     var view = new DataView({
       resourceId: id,
       endpoint: endpoint,
+      apiKey: apikey,
       el: $el
     });
   });


### PR DESCRIPTION
Pending ckan.js changes, this pull request sends the API key not only when creating the CKAN client directly but also via Dataset View creation so that the Recline backend in ckan.js can in turn create an authenticated client.